### PR TITLE
Upgrade clap to latest RC, fix imports

### DIFF
--- a/tools/test-bdf-parser/Cargo.toml
+++ b/tools/test-bdf-parser/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 bdf-parser = { path = "../../bdf-parser" }
-clap = "3.0.0-beta.2"
+clap = { version = "3.0.0-rc.7", features = [ "derive" ] }

--- a/tools/test-bdf-parser/src/main.rs
+++ b/tools/test-bdf-parser/src/main.rs
@@ -1,9 +1,9 @@
-use clap::Clap;
+use clap::Parser;
 use std::path::PathBuf;
 
 use test_bdf_parser::*;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Arguments {
     file_or_directory: PathBuf,
 }


### PR DESCRIPTION
Quick fix to some imports that changed since the last beta. I'm ok sitting on an `rc` release as we were on `beta` before anyway.

I think this breakage might have been caused by Cargo's versioning/semver rules picking a later beta than the one specified.