### PR TITLE
Add option to convert all glyphs in the source BDF

### DIFF
--- a/eg-font-converter/src/main.rs
+++ b/eg-font-converter/src/main.rs
@@ -40,6 +40,10 @@ struct Args {
     #[arg(long, num_args = 2, id = "char", conflicts_with = "mapping")]
     glyph_range: Vec<char>,
 
+    /// Include all glyphs from the source BDF data.
+    #[arg(long, conflicts_with_all = ["char", "mapping"])]
+    glyphs_from_font: bool,
+
     /// Type path to the embedded-graphics crate
     #[arg(long, default_value = "::embedded_graphics")]
     embedded_graphics_crate_path: String,
@@ -78,7 +82,9 @@ fn convert(args: &Args) -> Result<()> {
     let mut converter = FontConverter::new(bdf_file, name)
         .embedded_graphics_crate_path(&args.embedded_graphics_crate_path);
 
-    if args.glyph_range.is_empty() {
+    if args.glyphs_from_font {
+        converter = converter.glyphs_from_font();
+    } else if args.glyph_range.is_empty() {
         converter = converter.glyphs(args.mapping);
     } else {
         for range in args.glyph_range.chunks(2) {


### PR DESCRIPTION
I have a project using custom BDF fonts that I'd like to convert to `embedded-graphics`. Since it's for a specific clock display and I made the fonts myself, they're kind of weird:
* one with normal numbers, letters, and thin and hair spaces
* one with just bold numbers
* one with just characters for AM and PM in a smaller size

While I could manually specify the glyph ranges for each, that would be fiddly and could potentially get out of sync. I'd rather be able to convert all the glyphs in the source BDF directly, which is what this PR enables.

Add a new `glyphs_from_font` option (disabled by default, and I'm open to suggestions for a better name) that bypasses the specific glyphs/mapping options (and is mutually exclusive with them). While implementing this, I noticed that `FontConverter.mapping` was unused other than in the `ensure!()`, so I removed it.