### PR TITLE
fix: variable-sized bounding boxes

### DIFF
--- a/eg-font-converter/src/eg_bdf_font.rs
+++ b/eg-font-converter/src/eg_bdf_font.rs
@@ -32,12 +32,14 @@ pub struct EgBdfOutput {
     pub(crate) font: Font,
     data: BitVec<u8, Msb0>,
     glyphs: Vec<BdfGlyph>,
+    bounding_box: Rectangle,
 }
 
 impl EgBdfOutput {
     pub(crate) fn new(font: Font) -> Result<Self> {
         let mut data = BitVec::<u8, Msb0>::new();
         let mut glyphs = Vec::new();
+        let bounding_box = bounding_box_to_rectangle(&font.bdf.metadata.bounding_box);
 
         for glyph in font.glyphs.iter() {
             let bounding_box = bounding_box_to_rectangle(&glyph.bounding_box);
@@ -52,7 +54,12 @@ impl EgBdfOutput {
             data.extend(glyph.pixels());
         }
 
-        Ok(Self { font, data, glyphs })
+        Ok(Self {
+            font,
+            data,
+            glyphs,
+            bounding_box,
+        })
     }
 
     /// Returns the generated Rust code.
@@ -116,6 +123,11 @@ impl EgBdfOutput {
                 }
             };
         ))?))
+    }
+
+    /// Returns the font bounding box.
+    pub fn bounding_box(&self) -> Rectangle {
+        self.bounding_box
     }
 
     /// Returns the bitmap data.

--- a/eg-font-converter/src/mono_font.rs
+++ b/eg-font-converter/src/mono_font.rs
@@ -40,11 +40,7 @@ impl MonoFontOutput {
         let columns = glyphs_per_row; // TODO: allow smaller column count
         let rows = (font.glyphs.len() + (glyphs_per_row - 1)) / glyphs_per_row;
 
-        //TODO: don't assume that all glyphs are equally sized
-        //TODO: don't assume that at least one glyph is present (or is this already checked by EgBdfOutput)
-        let first_glyph = font.glyphs[0];
-
-        let character_size = first_glyph.bounding_box.size;
+        let character_size = bdf.bounding_box().size;
         let character_spacing = 0;
         let baseline = bdf.font.ascent.saturating_sub(1);
         let strikethrough = DecorationDimensions::new(


### PR DESCRIPTION
Even monospace fonts can have variable sized BBX fields. For characters with no data such as SPACE, the BBX can be 1x1. If space is the first character in the font, this leads to the converted font having all characters be 1x1 pixel.

To resolve the issue, use the FONTBOUNDINGBOX field for the bounding box instead of the BBX of the first character when converting.