### PR TITLE
Add support for non standard glyph encodings

### DIFF
--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -19,7 +19,7 @@ mod glyph;
 mod metadata;
 mod properties;
 
-pub use glyph::{Glyph, Glyphs};
+pub use glyph::{Encoding, Glyph, Glyphs};
 use helpers::*;
 pub use metadata::Metadata;
 pub use properties::{Properties, Property, PropertyError};
@@ -236,7 +236,7 @@ mod tests {
                         size: Coord::new(8, 8),
                         offset: Coord::new(0, 0),
                     },
-                    encoding: Some('@'), //64
+                    encoding: Encoding::Standard(64), // '@'
                     name: "Char 0".to_string(),
                     device_width: Coord::new(8, 0),
                     scalable_width: None,
@@ -247,7 +247,7 @@ mod tests {
                         size: Coord::new(8, 8),
                         offset: Coord::new(0, 0),
                     },
-                    encoding: Some('A'), //65
+                    encoding: Encoding::Standard(65), // 'A'
                     name: "Char 1".to_string(),
                     device_width: Coord::new(8, 0),
                     scalable_width: None,

--- a/eg-font-converter/src/eg_bdf_font.rs
+++ b/eg-font-converter/src/eg_bdf_font.rs
@@ -1,7 +1,7 @@
 use std::{fs, io, path::Path};
 
-use anyhow::Result;
-use bdf_parser::BoundingBox;
+use anyhow::{bail, Result};
+use bdf_parser::{BoundingBox, Encoding};
 use bitvec::{prelude::*, vec::BitVec};
 use eg_bdf::{BdfFont, BdfGlyph};
 use embedded_graphics::{
@@ -44,8 +44,15 @@ impl EgBdfOutput {
         for glyph in font.glyphs.iter() {
             let bounding_box = bounding_box_to_rectangle(&glyph.bounding_box);
 
+            // TODO: assumes unicode
+            // TODO: improved error handling
+            let character = match glyph.encoding {
+                Encoding::Standard(index) => char::from_u32(index).unwrap(),
+                _ => bail!("invalid encoding"),
+            };
+
             glyphs.push(BdfGlyph {
-                character: glyph.encoding.unwrap(),
+                character,
                 bounding_box,
                 device_width: glyph.device_width.x as u32, // TODO: check cast and handle y?
                 start_index: data.len(),


### PR DESCRIPTION
This PR improves how `-1` glyph encodings are handled by the parser. It adds a new `Encoding` enum to also support non standard encodings (`ENCODING -1 123`).