### PR TITLE
Add support for parsing writing mode 1 metrics

### DIFF
--- a/eg-font-converter/src/eg_bdf_font.rs
+++ b/eg-font-converter/src/eg_bdf_font.rs
@@ -53,10 +53,14 @@ impl EgBdfOutput {
                 }
             };
 
+            // TODO: error handling
+            // TODO: use y coordinate or ensure y is zero
+            let device_width = u32::try_from(glyph.width_horizontal.unwrap().device.x).unwrap();
+
             glyphs.push(BdfGlyph {
                 character,
                 bounding_box,
-                device_width: glyph.device_width.x as u32, // TODO: check cast and handle y?
+                device_width,
                 start_index: data.len(),
             });
 


### PR DESCRIPTION
This PR adds support for parsing BDF files that contain writing mode 1 metrics (`SWIDTH1`, `DWIDTH1` and `VVECTOR`).