### PR TITLE
Make font type names distinct

### DIFF
--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -18,7 +18,7 @@ use crate::parser::{Line, Lines};
 
 /// BDF Font.
 #[derive(Debug, Clone, PartialEq)]
-pub struct BdfFont {
+pub struct Font {
     /// Font metadata.
     pub metadata: Metadata,
 
@@ -26,7 +26,7 @@ pub struct BdfFont {
     pub glyphs: Glyphs,
 }
 
-impl BdfFont {
+impl Font {
     /// Parses a BDF file.
     pub fn parse(input: &str) -> Result<Self, ParserError> {
         let mut lines = Lines::new(input);
@@ -45,7 +45,7 @@ impl BdfFont {
         let metadata = Metadata::parse(&mut lines)?;
         let glyphs = Glyphs::parse(&mut lines, &metadata)?;
 
-        Ok(BdfFont { metadata, glyphs })
+        Ok(Font { metadata, glyphs })
     }
 }
 
@@ -143,7 +143,7 @@ mod tests {
     #[track_caller]
     pub(crate) fn assert_parser_error(input: &str, message: &str, line_number: Option<usize>) {
         assert_eq!(
-            BdfFont::parse(input),
+            Font::parse(input),
             Err(ParserError {
                 message: message.to_string(),
                 line_number,
@@ -183,7 +183,7 @@ mod tests {
         ENDFONT
     "#};
 
-    fn test_font(font: &BdfFont) {
+    fn test_font(font: &Font) {
         assert_eq!(
             font.metadata,
             Metadata {
@@ -249,7 +249,7 @@ mod tests {
 
     #[test]
     fn parse_font() {
-        test_font(&BdfFont::parse(FONT).unwrap())
+        test_font(&Font::parse(FONT).unwrap())
     }
 
     #[test]
@@ -260,7 +260,7 @@ mod tests {
             .collect();
         let input = lines.join("\n");
 
-        test_font(&BdfFont::parse(&input).unwrap());
+        test_font(&Font::parse(&input).unwrap());
     }
 
     #[test]
@@ -271,7 +271,7 @@ mod tests {
             .collect();
         let input = lines.join("\n");
 
-        test_font(&BdfFont::parse(&input).unwrap());
+        test_font(&Font::parse(&input).unwrap());
     }
 
     #[test]
@@ -282,7 +282,7 @@ mod tests {
             .collect();
         let input = lines.join("\n");
 
-        test_font(&BdfFont::parse(&input).unwrap());
+        test_font(&Font::parse(&input).unwrap());
     }
 
     #[test]
@@ -290,7 +290,7 @@ mod tests {
         let lines: Vec<_> = FONT.lines().collect();
         let input = lines.join("\r\n");
 
-        test_font(&BdfFont::parse(&input).unwrap());
+        test_font(&Font::parse(&input).unwrap());
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod tests {
         let lines: Vec<_> = std::iter::once("").chain(FONT.lines()).collect();
         let input = lines.join("\n");
 
-        test_font(&BdfFont::parse(&input).unwrap());
+        test_font(&Font::parse(&input).unwrap());
     }
 
     #[test]

--- a/bdf-parser/src/metadata.rs
+++ b/bdf-parser/src/metadata.rs
@@ -128,7 +128,7 @@ mod tests {
     use indoc::indoc;
 
     use super::*;
-    use crate::{tests::assert_parser_error, BdfFont};
+    use crate::{tests::assert_parser_error, Font};
 
     #[test]
     fn complete_metadata() {
@@ -142,7 +142,7 @@ mod tests {
             ENDFONT
         "#};
 
-        BdfFont::parse(FONT).unwrap();
+        Font::parse(FONT).unwrap();
     }
 
     #[test]
@@ -197,7 +197,7 @@ mod tests {
             ENDFONT
         "#};
 
-        let font = BdfFont::parse(FONT).unwrap();
+        let font = Font::parse(FONT).unwrap();
         assert_eq!(font.metadata.metrics_set, MetricsSet::Both);
     }
 }

--- a/eg-font-converter/src/eg_bdf_font.rs
+++ b/eg-font-converter/src/eg_bdf_font.rs
@@ -10,7 +10,7 @@ use embedded_graphics::{
 };
 use quote::{format_ident, quote};
 
-use crate::Font;
+use crate::ConvertedFont;
 
 /// Converts a BDF bounding box into an embedded-graphics rectangle.
 pub fn bounding_box_to_rectangle(bounding_box: &BoundingBox) -> Rectangle {
@@ -29,14 +29,14 @@ pub fn bounding_box_to_rectangle(bounding_box: &BoundingBox) -> Rectangle {
 /// [`eg-bdf`]: eg_bdf
 #[derive(Debug)]
 pub struct EgBdfOutput {
-    pub(crate) font: Font,
+    pub(crate) font: ConvertedFont,
     data: BitVec<u8, Msb0>,
     glyphs: Vec<BdfGlyph>,
     bounding_box: Rectangle,
 }
 
 impl EgBdfOutput {
-    pub(crate) fn new(font: Font) -> Result<Self> {
+    pub(crate) fn new(font: ConvertedFont) -> Result<Self> {
         let mut data = BitVec::<u8, Msb0>::new();
         let mut glyphs = Vec::new();
         let bounding_box = bounding_box_to_rectangle(&font.bdf.metadata.bounding_box);
@@ -83,7 +83,7 @@ impl EgBdfOutput {
     fn try_rust(&self) -> Result<String> {
         let constant_name = format_ident!("{}", self.font.name);
         let data_file = self.font.data_file().to_string_lossy().to_string();
-        let Font {
+        let ConvertedFont {
             replacement_character,
             ascent,
             descent,

--- a/eg-font-converter/src/mono_font.rs
+++ b/eg-font-converter/src/mono_font.rs
@@ -1,7 +1,7 @@
 use std::{fs, io, ops::RangeInclusive, path::Path};
 
 use anyhow::{bail, Context, Result};
-use bdf_parser::{BdfFont as ParserBdfFont, Encoding, Glyph};
+use bdf_parser::{Encoding, Font, Glyph};
 use eg_bdf::BdfTextStyle;
 use embedded_graphics::{
     image::ImageRaw,
@@ -13,12 +13,12 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay};
 use quote::{format_ident, quote};
 
-use crate::{EgBdfOutput, Font};
+use crate::{ConvertedFont, EgBdfOutput};
 
 /// Font conversion output for [`MonoFont`].
 #[derive(Debug)]
 pub struct MonoFontOutput {
-    font: Font,
+    font: ConvertedFont,
     bitmap: SimulatorDisplay<BinaryColor>,
     data: Vec<u8>,
 
@@ -207,7 +207,7 @@ impl MonoFontOutput {
     }
 
     /// Returns the BDF file.
-    pub fn bdf(&self) -> &ParserBdfFont {
+    pub fn bdf(&self) -> &Font {
         &self.font.bdf
     }
 

--- a/tools/test-bdf-parser/src/lib.rs
+++ b/tools/test-bdf-parser/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bdf_parser::*;
+use bdf_parser::Font;
 
 pub fn collect_font_files(dir: &Path) -> io::Result<Vec<PathBuf>> {
     let mut files = Vec::new();
@@ -32,7 +32,7 @@ pub fn collect_font_files(dir: &Path) -> io::Result<Vec<PathBuf>> {
 pub fn test_font_parse(filepath: &Path) -> Result<(), String> {
     let bdf = std::fs::read(filepath).unwrap();
     let str = String::from_utf8_lossy(&bdf);
-    let font = BdfFont::parse(&str);
+    let font = Font::parse(&str);
 
     match font {
         Ok(_font) => Ok(()),


### PR DESCRIPTION
The `bdf-parser` and `eg-bdf` both contained a type with the name `BdfFont`, which got a bit confusing in the converter which uses both types. This PR changes the names of the font types to be different across all crates.