### PR TITLE
Approximate ascent and descent if property is missing

### DIFF
--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -293,6 +293,10 @@ impl Glyphs {
             }
         }
 
+        if glyphs.is_empty() {
+            return Err(ParserError::new("no CHARS in font"));
+        }
+
         Ok(Self { glyphs })
     }
 
@@ -314,6 +318,32 @@ impl Glyphs {
     /// Returns an iterator over all glyphs.
     pub fn iter(&self) -> impl Iterator<Item = &Glyph> {
         self.glyphs.iter()
+    }
+
+    /// Approximates the ascent.
+    ///
+    /// See section 8.2.1 FONT_ASCENT in https://www.x.org/docs/XLFD/xlfd.pdf.
+    pub(crate) fn approximate_ascent(&self) -> u32 {
+        self.glyphs
+            .iter()
+            .map(|glyph| glyph.bounding_box.size.y - glyph.bounding_box.offset.y)
+            .max()
+            .unwrap_or_default()
+            .try_into()
+            .unwrap()
+    }
+
+    /// Approximates the descent.
+    ///
+    /// See section 8.2.2 FONT_DESCENT in https://www.x.org/docs/XLFD/xlfd.pdf.
+    pub(crate) fn approximate_descent(&self) -> u32 {
+        self.glyphs
+            .iter()
+            .map(|glyph| -glyph.bounding_box.offset.y)
+            .max()
+            .unwrap_or_default()
+            .try_into()
+            .unwrap()
     }
 }
 

--- a/bdf-parser/src/metadata.rs
+++ b/bdf-parser/src/metadata.rs
@@ -138,7 +138,10 @@ mod tests {
             FONTBOUNDINGBOX 0 1 2 3
             SIZE 1 2 3
             COMMENT "comment"
-            CHARS 0
+            CHARS 1
+            STARTCHAR 0
+            BITMAP
+            ENDCHAR
             ENDFONT
         "#};
 
@@ -193,7 +196,10 @@ mod tests {
             SIZE 1 2 3
             COMMENT "comment"
             METRICSSET 2
-            CHARS 0
+            CHARS 1
+            STARTCHAR 0
+            BITMAP
+            ENDCHAR
             ENDFONT
         "#};
 

--- a/eg-bdf-examples/examples/font_viewer.rs
+++ b/eg-bdf-examples/examples/font_viewer.rs
@@ -105,19 +105,19 @@ fn try_main() -> Result<()> {
         .nth(1)
         .ok_or_else(|| anyhow!("missing filename"))?;
 
-    let converted_font = FontConverter::with_file(&file, "BDF_FILE")
+    let converter = FontConverter::with_file(&file, "BDF_FILE")
         .glyphs(Mapping::Ascii)
         .missing_glyph_substitute('?');
 
-    let output = converted_font
+    let bdf_output = converter
         .convert_eg_bdf()
         .with_context(|| "couldn't convert font")?;
-    let bdf_font = output.as_font();
+    let bdf_font = bdf_output.as_font();
 
-    let output = converted_font
+    let mono_output = converter
         .convert_mono_font()
         .with_context(|| "couldn't convert font")?;
-    let mono_font = output.as_font();
+    let mono_font = mono_output.as_font();
 
     let hints_style = MonoTextStyle::new(&FONT_6X10, Rgb888::CSS_DIM_GRAY);
     let bottom_right = TextStyleBuilder::new()
@@ -125,7 +125,6 @@ fn try_main() -> Result<()> {
         .alignment(Alignment::Right)
         .build();
 
-    // TODO: add metrics getter
     let line_height = bdf_font.ascent + bdf_font.descent;
     let display_height = line_height * 8;
     let display_width = (line_height * 25).max(display_height);

--- a/eg-font-converter/src/eg_bdf_font.rs
+++ b/eg-font-converter/src/eg_bdf_font.rs
@@ -1,7 +1,7 @@
 use std::{fs, io, path::Path};
 
 use anyhow::Result;
-use bdf_parser::{BoundingBox, Encoding};
+use bdf_parser::{BoundingBox, Encoding, Metrics};
 use bitvec::{prelude::*, vec::BitVec};
 use eg_bdf::{BdfFont, BdfGlyph};
 use embedded_graphics::{
@@ -84,11 +84,14 @@ impl EgBdfOutput {
         let constant_name = format_ident!("{}", self.font.name);
         let data_file = self.font.data_file().to_string_lossy().to_string();
         let ConvertedFont {
+            bdf,
             replacement_character,
-            ascent,
-            descent,
             ..
-        } = self.font;
+        } = &self.font;
+
+        let Metrics {
+            ascent, descent, ..
+        } = bdf.metrics;
 
         let glyphs = self.glyphs.iter().map(|glyph| {
             let BdfGlyph {
@@ -150,10 +153,12 @@ impl EgBdfOutput {
 
     /// Returns the converted font as a [`BdfFont`].
     pub fn as_font(&self) -> BdfFont<'_> {
+        let metrics = &self.font.bdf.metrics;
+
         BdfFont {
             replacement_character: self.font.replacement_character,
-            ascent: self.font.ascent,
-            descent: self.font.descent,
+            ascent: metrics.ascent,
+            descent: metrics.descent,
             glyphs: &self.glyphs,
             data: self.data(),
         }

--- a/eg-font-converter/src/mono_font.rs
+++ b/eg-font-converter/src/mono_font.rs
@@ -35,6 +35,7 @@ pub struct MonoFontOutput {
 impl MonoFontOutput {
     pub(crate) fn new(bdf: EgBdfOutput) -> Result<Self> {
         let font = bdf.as_font();
+        let metrics = &bdf.font.bdf.metrics;
         let style = BdfTextStyle::new(&font, BinaryColor::On);
 
         let glyphs_per_row = 16; //TODO: make configurable
@@ -43,7 +44,7 @@ impl MonoFontOutput {
 
         let character_size = bdf.bounding_box().size;
         let character_spacing = 0;
-        let baseline = bdf.font.ascent.saturating_sub(1);
+        let baseline = metrics.ascent.saturating_sub(1);
         let strikethrough = DecorationDimensions::new(
             bdf.font.strikethrough_position,
             bdf.font.strikethrough_thickness,

--- a/tools/test-bdf-parser/src/main.rs
+++ b/tools/test-bdf-parser/src/main.rs
@@ -36,10 +36,9 @@ fn draw_specimen(style: impl TextRenderer<Color = Rgb888> + Copy) -> SimulatorDi
         Baseline::Top,
     );
 
-    // 10 px minimum line height to ensure output even if metrics are wrong.
-    let single_line_height = single_line.bounding_box().size.height.max(10);
+    let single_line_height = single_line.bounding_box().size.height;
 
-    let display_height = single_line_height * 3;
+    let display_height = (single_line_height * 3).max(10);
     let display_width = (single_line.bounding_box().size.width + 10).max(display_height);
 
     let text_position = Point::new(5, single_line_height as i32);


### PR DESCRIPTION
Some BDF fonts don't include the `FONT_ASCENT` and `FONT_DESCENT` property. This PR extends the parser to approximate these values when they are missing.